### PR TITLE
change ms (milliseconds) abbreviation to us (microseconds)

### DIFF
--- a/espr.py
+++ b/espr.py
@@ -57,7 +57,7 @@ def print_node(node, verbose=False):
     INDENT = '   '
     depth = node.get('depth', 0)
 
-    print('{}> {} {} ms'.format(
+    print('{}> {} {} us'.format(
         depth*INDENT,
         node.get('type'),
         int(node.get('time_in_nanos'))/1000


### PR DESCRIPTION
Almost had a heart attack when parsing the output. Alternatively change this to a decimal to keep it in ms