### PR TITLE
Fix aggregations profile not getting parsed

### DIFF
--- a/espr.py
+++ b/espr.py
@@ -80,10 +80,10 @@ def display(by_shard, verbose=False):
 
         searches = s.get('searches')
         if searches:
-            for s in searches:
+            for search in searches:
                 # don't care about other queries now
                 # just trying this out
-                for q in s['query']:
+                for q in search['query']:
                     ordered_nodes = tree_to_list(q)
                     for n in ordered_nodes:
                         print_node(n, verbose=verbose)


### PR DESCRIPTION
The outer loop variable `s` in `for s in by_shard` was shadowed by the inner `for s in searches` so, when a single profile response contains _both_ `aggregations` and `searches` property, the part where `aggregations` was being parsed – was not working correctly.

This PR should fix it. 